### PR TITLE
Bump lapin and bb8 versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        rust: [nightly, beta, stable, 1.45.0]
+        rust: [nightly, stable]
     steps:
       - uses: actions/checkout@v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.3.0 (2022-03-20)
+
+**Features**
+
+* Update to lapin 2.0
+* Support bb8 > 0.7.0
+
+## 0.2.0 (2021-05-20)
+
+**Features**
+
+* Update to tokio 1.0
+* Update to bb8 0.7.0
+
 ## 0.1.1 (2020-10-04)
 
 **Features**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "bb8-lapin"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Adrian Benavides <adri.benavides312@gmail.com>"]
 repository = "https://github.com/adrianbenavides/bb8-lapin"
 description = "r2d2-lapin, but for async tokio based connections"
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-bb8 = "0.7.0"
-lapin = "1.2"
+bb8 = "0.7"
+lapin = "2.0"
 
 [dev-dependencies]
 dotenv = "0.15"
 lazy_static = "1.4"
-tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "time", "sync"] }
-tokio-amqp = "1.0.0"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
+tokio-executor-trait = "2.1"
+tokio-reactor-trait = "1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use lapin::protocol::{AMQPError, AMQPErrorKind, AMQPHardError};
 use lapin::types::ShortString;
 use lapin::{ConnectionProperties, ConnectionState};
+use std::fmt;
 
 /// A `bb8::ManageConnection` implementation for `lapin::Connection`s.
 ///
@@ -36,7 +37,6 @@ use lapin::{ConnectionProperties, ConnectionState};
 ///     }
 /// }
 /// ```
-#[derive(Debug)]
 pub struct LapinConnectionManager {
     amqp_address: String,
     conn_properties: ConnectionProperties,
@@ -83,5 +83,13 @@ impl bb8::ManageConnection for LapinConnectionManager {
     fn has_broken(&self, conn: &mut Self::Connection) -> bool {
         let broken_states = vec![ConnectionState::Closed, ConnectionState::Error];
         broken_states.contains(&conn.status().state())
+    }
+}
+
+impl fmt::Debug for LapinConnectionManager {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LapinConnectionManager")
+            .field("amqp_address", &self.amqp_address)
+            .finish()
     }
 }

--- a/tests/connect.rs
+++ b/tests/connect.rs
@@ -1,6 +1,7 @@
 use bb8_lapin::prelude::*;
 use std::sync::Arc;
-use tokio_amqp::LapinTokioExt;
+use tokio_executor_trait::Tokio as TokioExecutor;
+use tokio_reactor_trait::Tokio as TokioReactor;
 
 lazy_static::lazy_static! {
     static ref AMQP_URL: String = {
@@ -11,7 +12,12 @@ lazy_static::lazy_static! {
 
 #[tokio::test]
 async fn can_connect() {
-    let manager = LapinConnectionManager::new(&AMQP_URL, ConnectionProperties::default().with_tokio());
+    let manager = LapinConnectionManager::new(
+        &AMQP_URL,
+        ConnectionProperties::default()
+            .with_executor(TokioExecutor::current())
+            .with_reactor(TokioReactor),
+    );
     let pool = Arc::new(
         bb8::Pool::builder()
             .max_size(2)


### PR DESCRIPTION
This patch introduces compatibility with bb8 0.7.1 and lapin 2.0.

### bb8 ###

For bb8, I removed the patch version from the cargo dependency requirement, as I'm assuming any future 0.7 versions will be compatible, and there will be less crate administration if the next required bump is with the future potential 0.8 release.

### lapin ###

`lapin::ConnectionProperties` no longer implements `std::fmt::Debug` in the 2.0 branch, so I had to change the lib's missing_debug_implementations policy. Implementing Debug by hand seemed to me to be a little out of scope for bb8-lapin.

In the connection test that uses tokio, I set the current Tokio runtime as the executor, as `amqp-tokio` is now deprecated and unused for lapin 2.x. I'm reasonably sure this is how lapin 2.0 expects its executor/reactor to be specified based on the documentation and source, but as the release was only five days ago and there is no official example, it's possible I got it wrong so I'd appreciate any feedback. I'm thinking about getting lapin's maintainer to comment on an example Tokio usage to confirm this.

### Other changes ###

I took the time to set 2021 as the Rust edition in Cargo.toml