### PR TITLE
Update to bb8 0.9 and bump lapin to 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.0 (2025-01-28)
+
+**Features**
+
+* Update to bb8 0.9.0
+* Update to lapin 2.5
+
 ## 0.5.0 (2023-03-28)
 
 **Features**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bb8-lapin"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Adrian Benavides <adri.benavides312@gmail.com>"]
 repository = "https://github.com/adrianbenavides/bb8-lapin"
 description = "r2d2-lapin, but for async tokio based connections"
@@ -8,9 +8,8 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1"
-bb8 = "0.8"
-lapin = "2.1"
+bb8 = "0.9"
+lapin = "2.5"
 
 [dev-dependencies]
 dotenv = "0.15"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ pub use lapin;
 /// Basic types to create a `LapinConnectionManager` instance.
 pub mod prelude;
 
-use async_trait::async_trait;
 use lapin::protocol::{AMQPError, AMQPErrorKind, AMQPHardError};
 use lapin::types::ShortString;
 use lapin::{ConnectionProperties, ConnectionState};
@@ -59,7 +58,6 @@ impl LapinConnectionManager {
     }
 }
 
-#[async_trait]
 impl bb8::ManageConnection for LapinConnectionManager {
     type Connection = lapin::Connection;
     type Error = lapin::Error;
@@ -69,7 +67,7 @@ impl bb8::ManageConnection for LapinConnectionManager {
     }
 
     async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
-        let valid_states = vec![ConnectionState::Initial, ConnectionState::Connecting, ConnectionState::Connected];
+        let valid_states = [ConnectionState::Initial, ConnectionState::Connecting, ConnectionState::Connected];
         if valid_states.contains(&conn.status().state()) {
             Ok(())
         } else {
@@ -81,7 +79,7 @@ impl bb8::ManageConnection for LapinConnectionManager {
     }
 
     fn has_broken(&self, conn: &mut Self::Connection) -> bool {
-        let broken_states = vec![ConnectionState::Closed, ConnectionState::Error];
+        let broken_states = [ConnectionState::Closed, ConnectionState::Error];
         broken_states.contains(&conn.status().state())
     }
 }


### PR DESCRIPTION
Update dependencies to the newest bb8 & lapin.

bb8 has removed its dependency on async_trait, being able to implement its interface with RPITIT, which means we can too! 🎉 

I've additionally bumped the version in one go to 0.6.0 in case you want to release it, @adrianbenavides 😃 