### PR TITLE
Update to lapin 3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.7.0 (2025-09-02)
+
+**Features**
+
+* Update to lapin 3.3.
+
+**Note**: `LapinConnectionManager`'s `Error` type has changed to
+`lapin::ErrorKind` to accommodate the type change in the lapin crate since
+version 3.0.
+
 ## 0.6.0 (2025-01-28)
 
 **Features**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bb8-lapin"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Adrian Benavides <adri.benavides312@gmail.com>"]
 repository = "https://github.com/adrianbenavides/bb8-lapin"
 description = "r2d2-lapin, but for async tokio based connections"
@@ -9,11 +9,11 @@ edition = "2021"
 
 [dependencies]
 bb8 = "0.9"
-lapin = "2.5"
+lapin = "3.3"
 
 [dev-dependencies]
 dotenv = "0.15"
 lazy_static = "1.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
-tokio-executor-trait = "2.1"
-tokio-reactor-trait = "1.1"
+tokio-executor-trait = "3.1"
+tokio-reactor-trait = "4.1"

--- a/tests/connect.rs
+++ b/tests/connect.rs
@@ -16,7 +16,7 @@ async fn can_connect() {
         &AMQP_URL,
         ConnectionProperties::default()
             .with_executor(TokioExecutor::current())
-            .with_reactor(TokioReactor),
+            .with_reactor(TokioReactor::current()),
     );
     let pool = Arc::new(
         bb8::Pool::builder()


### PR DESCRIPTION
Update for Lapin 3.x support, notably 3.3. Lapin's `lapin::Error` has changed, which is now reflected in the `bb8::ManageConnection` error type.

I've also added the current date and bumped the version in the changelog and [Cargo.toml](../blob/master/Cargo.toml).