### PR TITLE
Support for lapin 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.8.0 (upcoming)
+
+**Features**
+
+* Update to lapin 4, with support for lapin 4.0.2+
+
+**Breaking changes**:
+* `LapinConnectionManager`'s constructor `new` takes a
+`lapin::ConnectionBuilder` struct, which provides the URI, connection properties
+and the runtime to use. See the documentation for [ConnectionBuilder](https://docs.rs/lapin/latest/lapin/struct.ConnectionBuilder.html)
+for details.
+* `LapinConnectionManager` is now a generic type to accommodate a choice of
+runtime as expressed through the `async-rs` crate.
+
 ## 0.7.0 (2025-09-02)
 
 **Features**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bb8-lapin"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Adrian Benavides <adri.benavides312@gmail.com>"]
 repository = "https://github.com/adrianbenavides/bb8-lapin"
 description = "r2d2-lapin, but for async tokio based connections"
@@ -8,12 +8,12 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
+async-rs = "^0.8"
 bb8 = "0.9"
-lapin = "3.3"
+lapin = "~4.0.2"
 
 [dev-dependencies]
 dotenv = "0.15"
 lazy_static = "1.4"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
-tokio-executor-trait = "3.1"
-tokio-reactor-trait = "4.1"
+tokio-test = "0.4"

--- a/README.md
+++ b/README.md
@@ -4,16 +4,19 @@
 [![audit](https://github.com/adrianbenavides/bb8-lapin/workflows/Audit/badge.svg)](https://github.com/adrianbenavides/bb8-lapin/actions)
 [![crates.io-license](https://img.shields.io/crates/l/bb8-lapin)](LICENSE)
 
-[Lapin](https://github.com/CleverCloud/lapin) support for the [bb8](https://github.com/khuey/bb8) connection pool.
+[Lapin](https://github.com/amqp-rs/lapin) support for the [bb8](https://github.com/djc/bb8) connection pool.
 
 ## Usage
-See the documentation of bb8 for the details on how to use the connection pool.
+See the documentation of bb8 for the details on how to use the connection pool,
+and the documentation of lapin for how to create a ConnectionBuilder.
 
 ```rust
 use bb8_lapin::prelude::*;
 
 async fn example() {
-    let manager = LapinConnectionManager::new("amqp://guest:guest@127.0.0.1:5672//", ConnectionProperties::default());
+    let builder = DefaultConnectionBuilder::new().unwrap()
+        .with_uri_str("amqp://guest:guest@127.0.0.1:5672//".to_string());
+    let manager = LapinConnectionManager::new(builder);
     let pool = bb8::Pool::builder()
         .max_size(15)
         .build(manager)

--- a/examples/pool.rs
+++ b/examples/pool.rs
@@ -1,3 +1,4 @@
+use async_rs::Runtime;
 use bb8_lapin::prelude::*;
 
 #[tokio::main]
@@ -5,7 +6,8 @@ async fn main() {
     dotenv::dotenv().ok();
     let amqp_url = std::env::var("TEST_AMQP_URL").unwrap_or_else(|_| "amqp://guest:guest@127.0.0.1:5672//".to_string());
 
-    let manager = LapinConnectionManager::new(&amqp_url, ConnectionProperties::default());
+    let builder = ConnectionBuilder::new_with_runtime(Runtime::tokio_current()).with_uri_str(amqp_url);
+    let manager = LapinConnectionManager::new(builder);
     let pool = bb8::Pool::builder().max_size(15).build(manager).await.unwrap();
 
     for _ in 0..20 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,10 @@ pub use lapin;
 /// Basic types to create a `LapinConnectionManager` instance.
 pub mod prelude;
 
+use async_rs::traits::RuntimeKit;
 use lapin::protocol::{AMQPError, AMQPErrorKind, AMQPHardError};
 use lapin::types::ShortString;
-use lapin::{ConnectionProperties, ConnectionState};
-use std::fmt;
+use lapin::ConnectionBuilder;
 
 /// A `bb8::ManageConnection` implementation for `lapin::Connection`s.
 ///
@@ -19,7 +19,11 @@ use std::fmt;
 /// use bb8_lapin::prelude::*;
 ///
 /// async fn example() {
-///     let manager = LapinConnectionManager::new("amqp://guest:guest@127.0.0.1:5672//", ConnectionProperties::default());
+///     let manager = LapinConnectionManager::new(
+///         DefaultConnectionBuilder::new()
+///             .unwrap()
+///             .with_uri_str("amqp://guest:guest@127.0.0.1:5672//".to_string())
+///     );
 ///     let pool = bb8::Pool::builder()
 ///         .max_size(15)
 ///         .build(manager)
@@ -36,41 +40,41 @@ use std::fmt;
 ///     }
 /// }
 /// ```
-pub struct LapinConnectionManager {
-    amqp_address: String,
-    conn_properties: ConnectionProperties,
+#[derive(Debug)]
+pub struct LapinConnectionManager<RK: RuntimeKit + Send + Sync + Clone + 'static> {
+    conn_builder: ConnectionBuilder<RK>,
 }
 
-impl LapinConnectionManager {
+impl<RK: RuntimeKit + Send + Sync + Clone + 'static> LapinConnectionManager<RK> {
     /// Initialize the connection manager with the data needed to create new connections.
-    /// Refer to the documentation of [`lapin::ConnectionProperties`](https://docs.rs/lapin/1.2.8/lapin/struct.ConnectionProperties.html)
-    /// for further details on the available connection parameters.
+    /// Refer to the documentation of [`lapin::ConnectionBuilder`](https://docs.rs/lapin/latest/lapin/struct.ConnectionBuilder.html)
+    /// for further details on connection settings.
     ///
     /// # Example
     /// ```
-    /// let manager = bb8_lapin::LapinConnectionManager::new("amqp://guest:guest@127.0.0.1:5672//", lapin::ConnectionProperties::default());
+    /// # tokio_test::block_on(async {
+    /// let manager = bb8_lapin::LapinConnectionManager::new(
+    ///     lapin::DefaultConnectionBuilder::new().unwrap()
+    ///         .with_uri_str("amqp://guest:guest@127.0.0.1:5672//".to_string())
+    /// );
+    /// # })
     /// ```
-    pub fn new(amqp_address: &str, conn_properties: ConnectionProperties) -> Self {
-        Self {
-            amqp_address: amqp_address.to_string(),
-            conn_properties,
-        }
+    pub fn new(conn_builder: ConnectionBuilder<RK>) -> Self {
+        Self { conn_builder }
     }
 }
 
-impl bb8::ManageConnection for LapinConnectionManager {
+impl<RK: RuntimeKit + Send + Sync + Clone + 'static> bb8::ManageConnection for LapinConnectionManager<RK> {
     type Connection = lapin::Connection;
     type Error = lapin::ErrorKind;
 
     async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        lapin::Connection::connect(&self.amqp_address, self.conn_properties.clone())
-            .await
-            .map_err(|e| e.kind().to_owned())
+        self.conn_builder.connect().await.map_err(|e| e.kind().to_owned())
     }
 
     async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
-        let valid_states = [ConnectionState::Initial, ConnectionState::Connecting, ConnectionState::Connected];
-        if valid_states.contains(&conn.status().state()) {
+        let conn_status = conn.status();
+        if !conn_status.closing() && !conn_status.closed() && !conn_status.errored() {
             Ok(())
         } else {
             Err(lapin::ErrorKind::ProtocolError(AMQPError::new(
@@ -81,15 +85,7 @@ impl bb8::ManageConnection for LapinConnectionManager {
     }
 
     fn has_broken(&self, conn: &mut Self::Connection) -> bool {
-        let broken_states = [ConnectionState::Closed, ConnectionState::Error];
-        broken_states.contains(&conn.status().state())
-    }
-}
-
-impl fmt::Debug for LapinConnectionManager {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("LapinConnectionManager")
-            .field("amqp_address", &self.amqp_address)
-            .finish()
+        let conn_status = conn.status();
+        conn_status.closed() || conn_status.errored()
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,4 @@
 pub use crate::LapinConnectionManager;
+pub use async_rs::Runtime;
 pub use bb8;
-pub use lapin::ConnectionProperties;
+pub use lapin::{ConnectionBuilder, DefaultConnectionBuilder};

--- a/tests/connect.rs
+++ b/tests/connect.rs
@@ -1,7 +1,5 @@
 use bb8_lapin::prelude::*;
 use std::sync::Arc;
-use tokio_executor_trait::Tokio as TokioExecutor;
-use tokio_reactor_trait::Tokio as TokioReactor;
 
 lazy_static::lazy_static! {
     static ref AMQP_URL: String = {
@@ -12,12 +10,8 @@ lazy_static::lazy_static! {
 
 #[tokio::test]
 async fn can_connect() {
-    let manager = LapinConnectionManager::new(
-        &AMQP_URL,
-        ConnectionProperties::default()
-            .with_executor(TokioExecutor::current())
-            .with_reactor(TokioReactor::current()),
-    );
+    let builder = ConnectionBuilder::new_with_runtime(Runtime::tokio_current()).with_uri_str(AMQP_URL.to_owned());
+    let manager = LapinConnectionManager::new(builder);
     let pool = Arc::new(
         bb8::Pool::builder()
             .max_size(2)


### PR DESCRIPTION
Here is support for lapin 4.x.x, and an update to the version.

I've changed the interface to use only the new `lapin::ConnectionBuilder` instead of taking the AMQP URI and ConnectionProperties separately. The builder is typed depending on the async runtime used, so `LapinConnectionManager` is now generically typed as well.